### PR TITLE
Extends highlighted hex colors to include #n and #nn.

### DIFF
--- a/syntax/stylus.vim
+++ b/syntax/stylus.vim
@@ -33,6 +33,7 @@ syn match cssUIProp contained "\<\(transition\)\>"
 syn keyword cssColorProp contained opacity
 syn match cssTextAttr contained "\<text-shadow\|text-overflow\|word-wrap\>"
 syn match cssColorProp contained "\<background\(-\(origin\|clip\|size\|position\|attachment\|image\|color\|repeat\)\)\="
+syn match cssColor contained "#[0-9A-Fa-f]\{1,2\}\>"
 syn match cssColor contained "\<rgb\s*(\s*\d\+\(\.\d*\)\=%\=\s*,\s*\d\+\(\.\d*\)\=%\=\s*,\s*\d\+\(\.\d*\)\=%\=\s*)"
 syn match cssColor contained "\<rgba\s*(\s*\d\+\(\.\d*\)\=%\=\s*,\s*\d\+\(\.\d*\)\=%\=\s*,\s*\d\+\(\.\d*\)\=%\=\s*,\s*\d\+\(\.\d*\)\=%\=\s*)"
 syn match cssColor contained "\<hsl\s*(\s*\d\+\(\.\d*\)\=%\=\s*,\s*\d\+\(\.\d*\)\=%\=\s*,\s*\d\+\(\.\d*\)\=%\=\s*)"


### PR DESCRIPTION
Stylus 0.18.0 added hex color expansion support for #a (to #aaaaaa) and #ab (to #ababab), similar to how plain css expands #abc to #abcabc.
