### PR TITLE
Fixes compatibility issue with other plugins

### DIFF
--- a/syntax/stylus.vim
+++ b/syntax/stylus.vim
@@ -306,9 +306,9 @@ endif
 
 " let b:current_syntax = "css"
 " 
-" if main_syntax == 'css'
-"   unlet main_syntax
-" endif
+if main_syntax == 'css'
+  unlet main_syntax
+endif
 
 " Vim syntax file
 " Language: Stylus


### PR DESCRIPTION
This error appears with other syntax plugins (like vim-jade) when editing .styl files before the other file types.

```
Vim(if):E121: Undefined variable: main_syntax
```
