### PR TITLE
Changed definition of keyword.

### DIFF
--- a/ftplugin/stylus.vim
+++ b/ftplugin/stylus.vim
@@ -45,6 +45,11 @@ endif
 
 setlocal comments= commentstring=//\ %s
 
+" Add '-' and '#' to the what makes up a keyword.
+" This means that 'e' and 'w' work properly now, for properties
+" and valid variable names.
+setl iskeyword+=#,-
+
 let b:undo_ftplugin = "setl cms< com< "
       \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin
 

--- a/syntax/stylus.vim
+++ b/syntax/stylus.vim
@@ -352,7 +352,9 @@ syn match stylusEscape     "^\s*\zs\\"
 syn match stylusId         "[[:alnum:]_-]\+" contained
 syn match stylusIdChar     "#[[:alnum:]_-]\@=" nextgroup=stylusId
 
-syn match  stylusComment    "\/\/\s.*" contains=cssTodo,@Spell fold
+" TODO: Fix the weird region/containment situation. This region should not be
+" allowed in a url() function... thingy! Then we can get rid of that pesky '\s'.
+syn region stylusComment    start="//\s" end="$" contains=cssTodo,@Spell fold
 
 hi def link stylusComment               Comment
 hi def link stylusVariable              Identifier


### PR DESCRIPTION
Now `e` and `w` and `*` work on CSS property names, hexadecimal colours, and hyphen-separated-variables. Wee!

Also, the definition of a Stylus comment as `//\s` was annoying me (sometimes I'm lazy and just want to comment-out one property!), but I'm too unexperienced with Vim syntax highlighting to make it work properly. I _think_ that the regions are messed up concerning `cssFuncVal`. All I want is for `//` to not start a comment in `url(...)` regions!
