### PR TITLE
Fix syntax highlighting for comments

### DIFF
--- a/syntax/stylus.vim
+++ b/syntax/stylus.vim
@@ -330,7 +330,7 @@ syn match stylusProperty "\%([{};]\s*\|^\)\@<=\%([[:alnum:]-]\|#{[^{}]*}\)\+:" c
 syn match stylusProperty "^\s*\zs\s\%(\%([[:alnum:]-]\|#{[^{}]*}\)\+[ :]\|:[[:alnum:]-]\+\)"hs=s+1 contains=@stylusCssProperties,@stylusCssSelectors skipwhite nextgroup=stylusCssAttribute
 syn match stylusProperty "^\s*\zs\s\%(:\=[[:alnum:]-]\+\s*=\)"hs=s+1 contains=@stylusCssProperties,@stylusCssSelectors skipwhite nextgroup=stylusCssAttribute
 
-syn match stylusCssAttribute +\%("\%([^"]\|\\"\)*"\|'\%([^']\|\\'\)*'\|#{[^{}]*}\|[^{};]\)*+ contained contains=@stylusCssValues,cssImportant,stylusFunction,stylusVariable,stylusControl,stylusUserFunction,stylusInterpolation,stylusComment,cssComment
+syn match stylusCssAttribute +\%("\%([^"]\|\\"\)*"\|'\%([^']\|\\'\)*'\|#{[^{}]*}\|[^{};]\)*+ contained contains=@stylusCssValues,cssImportant,stylusFunction,stylusVariable,stylusControl,stylusUserFunction,stylusInterpolation,cssString,stylusComment,cssComment
 
 syn match stylusInterpolation %{[[:alnum:]_-]\+}%
 
@@ -352,9 +352,7 @@ syn match stylusEscape     "^\s*\zs\\"
 syn match stylusId         "[[:alnum:]_-]\+" contained
 syn match stylusIdChar     "#[[:alnum:]_-]\@=" nextgroup=stylusId
 
-" TODO: Fix the weird region/containment situation. This region should not be
-" allowed in a url() function... thingy! Then we can get rid of that pesky '\s'.
-syn region stylusComment    start="//\s" end="$" contains=cssTodo,@Spell fold
+syn region stylusComment    start="//" end="$" contains=cssTodo,@Spell fold
 
 hi def link stylusComment               Comment
 hi def link stylusVariable              Identifier

--- a/test.styl
+++ b/test.styl
@@ -13,7 +13,7 @@ if padding-overloaded
 
 border-radius()
   -webkit-border-radius arguments // comment test
-  -moz-border-radius arguments
+  -moz-border-radius arguments //comment test
   border-radius arguments
 
 #myid {
@@ -42,6 +42,7 @@ body a:hover
   color #000
   float left
   display: block
+  background url('http://i.imgur.com/Q4RObrY.jpg')
 
 #myid
   font 12px/1.4 "Lucida Grande", Arial, sans-serif


### PR DESCRIPTION
Anything that starts with `//` is a comment.
