### PR TITLE
Enable jump to file on abbreviated @import

### DIFF
--- a/ftplugin/stylus.vim
+++ b/ftplugin/stylus.vim
@@ -45,6 +45,8 @@ endif
 
 setlocal comments= commentstring=//\ %s
 
+setlocal suffixesadd=.styl
+
 " Add '-' and '#' to the what makes up a keyword.
 " This means that 'e' and 'w' work properly now, for properties
 " and valid variable names.


### PR DESCRIPTION
For the stylus:

```
@import layout
```

If you do `gf` on `layout` it should automatically check for (and 
jump to) `layout.styl`
