### PR TITLE
Correctly recognize cssPseudo classes for indent

### DIFF
--- a/indent/stylus.vim
+++ b/indent/stylus.vim
@@ -117,7 +117,7 @@ function! GetStylusIndent()
 
   " if group !~? 'css.*' && line =~? ')\s*$' " match user functions
   "   return increase
-  if group =~? '\v^%(cssTagName|cssClassName|cssIdentifier|cssSelectorOp|cssSelectorOp2|cssBraces|cssAttributeSelector|cssPseudoClass|cssPseudoClassId|stylusId|stylusClass)$'
+  if group =~? '\v^%(cssTagName|cssClassName|cssIdentifier|cssSelectorOp|cssSelectorOp2|cssBraces|cssAttributeSelector|cssPseudo|stylusId|stylusClass)$'
     return increase
   elseif (group == 'stylusUserFunction') && (indent(lnum) == '0') " mixin definition
     return increase

--- a/test.styl
+++ b/test.styl
@@ -68,6 +68,9 @@ body a:hover
   color red(10) lighten(he) border-radius() image-size()
   border-radius border-radius()
 
+  &:hover
+    color black // Tests indent from the line above
+
 form input {
   padding: 5px;
   border: 1px solid;


### PR DESCRIPTION
This fixes a problem where a section like this:

```
  .some-class
    &:hover
      color gray
```

if you invoked indention after the &:hover line, it would not indent a new level.

Hope this is the right way to contribute, let me know if there is a different policy on how to submit PRs, I have another change around flex attributes

